### PR TITLE
Adding basic form validation to the Basic Info form.

### DIFF
--- a/client/src/components/RegisterVolunteer/BasicInfoForm.jsx
+++ b/client/src/components/RegisterVolunteer/BasicInfoForm.jsx
@@ -72,7 +72,7 @@ export default function BasicInfoForm() {
 
     const invalidFields = Object.keys(invalid);
 
-    if (!invalidFields.length && 0) {
+    if (!invalidFields.length) {
       Volunteer.updateInfo(basicInfo);
       Volunteer.setRegistrationStep(2);
 

--- a/client/src/components/RegisterVolunteer/BasicInfoForm.jsx
+++ b/client/src/components/RegisterVolunteer/BasicInfoForm.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useContext } from 'react';
-import { Box, Grid, TextField, Typography, Button } from '@mui/material';
+import React, { useState, useContext, useRef } from 'react';
+import { Box, Grid, TextField, Typography, Button, FormControl } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { ReactComponent as ErrorIcon } from '../../assets/Error.svg';
 
@@ -10,9 +10,7 @@ const useStyles = makeStyles({
     '& .MuiOutlinedInput-input': {
       width: '328px',
     },
-    '& .MuiOutlinedInput-root': {
-      marginBottom: '32px',
-    }
+
   }
 
 });
@@ -24,6 +22,13 @@ export default function BasicInfoForm() {
     name: Volunteer.name || '',
     pronouns: '',
   });
+
+  const [errors, setErrors] = useState({
+    name: false,
+    email: false,
+    pronouns: false,
+  });
+
 
   const classes = useStyles();
   const completed = () => {
@@ -41,75 +46,115 @@ export default function BasicInfoForm() {
     setBasicInfo({
       ...basicInfo,
       [e.target.name]: e.target.value,
-    })
-  }
+    });
+  };
+
+
+
 
   const updateVolunteer = () => {
-    Volunteer.updateInfo(basicInfo);
-    Volunteer.setRegistrationStep(2);
+    let invalid = {};
+
+    // Full Name Validation
+    if (basicInfo.name.length<=3 || basicInfo.name.split(' ').length<2) {
+      invalid.name = true;
+    }
+
+    // Pronouns Validation
+    if (basicInfo.pronouns.length<=4) {
+      invalid.pronouns = true;
+    }
+
+    // Email Validation
+    if (basicInfo.email.length<=5 || !basicInfo.email.match(/^(.+)@(.+)$/)) {
+      invalid.email = true;
+    }
+
+    const invalidFields = Object.keys(invalid);
+
+    if (!invalidFields.length && 0) {
+      Volunteer.updateInfo(basicInfo);
+      Volunteer.setRegistrationStep(2);
+
+    } else {
+      for (let i=0; i<invalidFields.length; i+=1) {
+        const key = invalidFields[i];
+        setErrors(e => ({
+          ...e,
+          [key]: true
+        }));
+        
+      }
+    }
+
+    return true;
   };
 
   return (<>
-    <Grid container justifyContent="flex-end" className={classes.ContentArea}>
-      <Grid item sm={9} xs={11}>
-        <Typography variant="h4" component="h1" mb="16px">Basic Info</Typography>
-        <Typography mb="16px">Input basic info about yourself</Typography>
-        <Box mb="32px">
-          <ErrorIcon variant="filled" sx={{ display: 'inline-block' }} /> 
-          <Typography component="div" color="#B00020" sx={{ display: 'inline-block', marginLeft: '10px', verticalAlign: 'top'}}>All fields are required</Typography>
-        </Box>
-      </Grid>
-      <Grid item sm={9} xs={11}>
-        <TextField
-          id="emailAddress"
-          type="text"
-          name="email"
-          label="Email Address"
-          placeholder="email@domain.com"
-          InputLabelProps={{ shrink: true, color: 'secondary' }}
-          onChange={updateInfo}
-          defaultValue={Volunteer?.email}
-        />
-      </Grid>
+      <Grid container justifyContent="left" className={classes.ContentArea}>
+        <Grid item sm={4} xs={1} />
+        <Grid item sm={3} xs={10}>
+          <Typography variant="h4" component="h1" mb="16px">Basic Info</Typography>
+          <Typography mb="16px">Input basic info about yourself</Typography>
+          <Box mb="32px">
+            <ErrorIcon variant="filled" sx={{ display: 'inline-block' }} /> 
+            <Typography component="div" color="#B00020" sx={{ display: 'inline-block', marginLeft: '10px', verticalAlign: 'top'}}>All fields are required</Typography>
+          </Box>
+          <FormControl sx={{ width: '100%', marginBottom: '32px' }}>
+            <TextField
+              id="emailAddress"
+              error={errors.email}
+              type="email"
+              name="email"
+              onChange={updateInfo}
+              label="Email Address"
+              placeholder="email@domain.com"
+              InputLabelProps={{ shrink: true, color: 'secondary' }}
+              defaultValue={Volunteer?.email} 
+              helperText={errors.email ? 'Please enter a valid email address.' : ''}
+            />
+          </FormControl>
 
-      <Grid item sm={9} xs={11}>
-        <TextField
-          id="fullName"
-          type="text"
-          name="name"
-          label="Full Name"
-          placeholder="How would you want to be addressed?"
-          InputLabelProps={{ shrink: true, color: 'secondary' }}
-          onChange={updateInfo}
-          defaultValue={Volunteer?.name}
-        />
-      </Grid>
+          <FormControl sx={{ width: '100%', marginBottom: '32px' }}>
+            <TextField
+              error={errors.name}
+              id="fullName"
+              type="text"
+              name="name"
+              onChange={updateInfo}
+              label="Full Name"
+              placeholder="How would you want to be addressed?"
+              InputLabelProps={{ shrink: true, color: 'secondary' }}
+              defaultValue={Volunteer?.name}
+              helperText={errors.name ? 'Please include your full name.' : ''}
+            />
+          </FormControl>
 
-      <Grid item sm={9} xs={11}>
-        <TextField
-          id="pronouns"
-          type="text"
-          name="pronouns"
-          onChange={updateInfo}
-          label="Pronouns"
-          placeholder="How would you want to be addressed?"
-          InputLabelProps={{ shrink: true, color: 'secondary' }}
-          InputProps={{ color: 'secondary' }}
-        />
-      </Grid>
+          <FormControl sx={{ width: '100%', marginBottom: '32px' }}>
+            <TextField
+              error={errors.pronouns}
+              id="pronouns"
+              type="text"
+              name="pronouns"
+              onChange={updateInfo}
+              label="Pronouns"
+              placeholder="How would you want to be addressed?"
+              InputLabelProps={{ shrink: true, color: 'secondary' }}
+              InputProps={{ color: 'secondary' }}
+              helperText={errors.pronouns ? 'Please let us know your pronouns.' : ''}
+            />
+          </FormControl>
 
-      <Grid item sm={9} xs={11}>
-        <Button
-          size="medium"
-          variant="contained"
-          onClick={completed() ? () => updateVolunteer() : null}
-          type="button"
-          disabled={!basicInfo.pronouns || !basicInfo.name || !basicInfo.email}
-        >
-          Next
-        </Button>
-      </Grid>
 
-    </Grid>
+            <Button
+              size="medium"
+              variant="contained"
+              onClick={completed() ? () => updateVolunteer() : null}
+              disabled={!basicInfo.pronouns || !basicInfo.name || !basicInfo.email}
+              type="button">
+              Next
+            </Button>
+        </Grid>
+      </Grid>
   </>);
 }


### PR DESCRIPTION
Added basic form validation to the "Basic Info" step and restructured the form a bit since the styles were off.

- Updated Grid tags to match the design better. 
- Changed email input to use type="email" to enable the browser to validate the email address.
- Added custom validation for email on top of that. Checks length >5, validates against a basic regex.
- Added custom validation for name, checks for 2 words with a basic length of at least 3.
- Added custom validation for pronouns, checks length for more than 4.
- Added error helper text and styling. Fields turn red on error and display error helper message if the input is invalid.
