### PR TITLE
Slack Message Admins when Volunteers Accept / Reject a Project

### DIFF
--- a/db/controllers/admins.controller.js
+++ b/db/controllers/admins.controller.js
@@ -22,6 +22,16 @@ const getAdmin = async (req, res) => {
     }
 }
 
+const getAdminEmails = async (req, res) => {
+    let error; 
+    const result = await models.admin.findAll({
+        attributes: ['email']
+    })
+        .catch(err => error = err);
+
+    return error ? error : result;
+}
+
 const addAdmin = async (req, res) => {
     let error;
     const {
@@ -155,6 +165,7 @@ const logout = async (req, res) => {
 
 module.exports = {
     getAdmin,
+    getAdminEmails,
     addAdmin,
     editAdmin,
     changePassword,

--- a/db/controllers/slack.controller.js
+++ b/db/controllers/slack.controller.js
@@ -1,6 +1,7 @@
 const slack = require('../lib/slack/slack');
 const blocks = require('../lib/slack/blocks');
 const { models } = require('../index');
+const { getAdminEmails } = require('./admins.controller');
 const axios = require('axios');
 
 const responses = {
@@ -113,6 +114,20 @@ const sendProjectWelcomeToVolunteer = async (req, res) => {
     return res.status(200).json({ result: 'Success!' });
 };
 
+const notifyAdminsYes = async (volunteer, project) => {
+    const emails = await getAdminEmails();
+    const slackIds = [];
+    await Promise.all(emails.map( async (email) => {
+        const response = await slack.slackLookupByEmail(email.email);
+        if (response.data.ok) {
+            slackIds.push(response.data.user.id);
+            return response.data.user.id;
+        }
+    }));
+    console.log(slackIds);
+    return slackIds;
+};
+
 const receiveUserResponse = async (req, res) => {
     const { payload } = req.body;
     const parsedPayload = JSON.parse(payload);
@@ -150,5 +165,6 @@ const receiveUserResponse = async (req, res) => {
 module.exports = {
     slackBot,
     sendProjectWelcomeToVolunteer,
-    receiveUserResponse
+    receiveUserResponse,
+    notifyAdminsYes
 };

--- a/db/lib/slack/blocks.js
+++ b/db/lib/slack/blocks.js
@@ -195,7 +195,46 @@ const messageBlocks = {
         }
 
         return blocks;
-    }
+    },
+
+    /**
+     * Notifaction to an admin informing them that the volunteer accepted the project. 
+     * 
+     * @param {string} volunteerName - name of the volunteer.
+     * @param {string} projectName - name of the project
+     * @returns {array} - Slack block array of block objects.
+     */
+    notifyAdminConfirm: (volunteerName, projectName) => {
+        return [
+            {
+                type: "section",
+                text: {
+                    type: "mrkdwn",
+                    text: `Project recommendation alert: *${volunteerName}* has accepted the recommended project and has conditionally joined *${projectName}*.`
+                }
+            }
+        ]
+    },
+
+     /**
+     * Notifaction to an admin informing them that the volunteerd declined the project. 
+     * 
+     * @param {string} volunteerName - name of the volunteer.
+     * @param {string} projectName - name of the project
+     * @returns {array} - Slack block array of block objects.
+     */
+     notifyAdminDecline: (volunteerName, projectName) => {
+        return [
+            {
+                type: "section",
+                text: {
+                    type: "mrkdwn",
+                    text: `Project recommendation alert: *${volunteerName} has rejected the recommended project, *${projectName}, and has opted to schedule a 1:1 with you.`
+                }
+            }
+        ]
+    },
+
 
 };
 

--- a/db/lib/slack/blocks.js
+++ b/db/lib/slack/blocks.js
@@ -200,17 +200,16 @@ const messageBlocks = {
     /**
      * Notifaction to an admin informing them that the volunteer accepted the project. 
      * 
-     * @param {string} volunteerName - name of the volunteer.
-     * @param {string} projectName - name of the project
+     * @param {object} details - object containing name of the volunteer and name of project.
      * @returns {array} - Slack block array of block objects.
      */
-    notifyAdminConfirm: (volunteerName, projectName) => {
+    notifyAdminConfirm: (details) => {
         return [
             {
                 type: "section",
                 text: {
                     type: "mrkdwn",
-                    text: `Project recommendation alert: *${volunteerName}* has accepted the recommended project and has conditionally joined *${projectName}*.`
+                    text: `Project recommendation alert: *${details.volunteer}* has accepted the recommended project and has conditionally joined *${details.project}*.`
                 }
             }
         ]
@@ -219,17 +218,16 @@ const messageBlocks = {
      /**
      * Notifaction to an admin informing them that the volunteerd declined the project. 
      * 
-     * @param {string} volunteerName - name of the volunteer.
-     * @param {string} projectName - name of the project
+     * @param {object} details - object containing name of the volunteer and name of project.
      * @returns {array} - Slack block array of block objects.
      */
-     notifyAdminDecline: (volunteerName, projectName) => {
+     notifyAdminDecline: (details) => {
         return [
             {
                 type: "section",
                 text: {
                     type: "mrkdwn",
-                    text: `Project recommendation alert: *${volunteerName} has rejected the recommended project, *${projectName}, and has opted to schedule a 1:1 with you.`
+                    text: `Project recommendation alert: *${details.volunteer}* has rejected the recommended project, *${details.project}*, and has opted to schedule a 1:1 with you.`
                 }
             }
         ]


### PR DESCRIPTION
When a volunteer accepts or rejects a project, send a slack message to all admins letting notifying them of the volunteer's decision. 