### PR TITLE
Add Slackbot Functionality for Volunteer Tasks

### DIFF
--- a/db/controllers/volunteers.controller.js
+++ b/db/controllers/volunteers.controller.js
@@ -3,6 +3,7 @@ require('dotenv').config({
 });
 const { models } = require('../index');
 const { slackLookupByEmail } = require('../lib/slack/slack');
+const { sendTaskCheckboxes } = require('./slack.controller');
 const tasks = require('../constants/tasks');
 const { response } = require('express');
 const { addTimeslots } = require('./timeslots.controller');
@@ -150,6 +151,7 @@ const addVolunteer = async (req, res) => {
 
     if (volunteerRec) {
         addRegisteredEvent(volunteerRec.id);
+        sendTaskCheckboxes(volunteerRec);
     }
     res.json({ success: true });
 };

--- a/db/lib/slack/blocks.js
+++ b/db/lib/slack/blocks.js
@@ -6,7 +6,51 @@
  * level "blocks" key out. Properly formatted it should be [{},{},{}].
  */
 const messageBlocks = {
+    /**
+     * 
+     * @param {object} volunteer - the volunteer object
+     */
+    volunteerTasks: (volunteer) => {
+        return [{
+            type: "section", 
+            text: {
+                type: "mrkdwn",
+                text: `Hi ${volunteer.name}, thank you for registering!`
+            }
+        }, {
+            type: "section", 
+            text: {
+                type: "mrkdwn",
+                text: "You've been assigned three tasks on Trello. After completing one, please mark it as done by clicking the checkbox."
+            }
+        }, {
+            type: "actions",
+            elements: [{
+                type: "checkboxes",
+                "action_id": "task_complete",
+                options: [{
+                    text: {
+                        type: "plain_text",
+                        text: "Watch onboarding videos"
+                    },
+                    value: "watched_video"
+                }, {
+                    text: {
+                        type: "plain_text",
+                        text: "Submit passcode validation"
+                    },
+                    value: "submitted_passcode"
+                }, {
+                    text: {
+                        type: "plain_text",
+                        text: "Submit skills survey"
+                    },
+                    value: "submitted_survey"
+                }]
 
+            }]
+        }]
+    },
     /**
      * Welcome to project message block.
      * 

--- a/db/lib/slack/blocks.js
+++ b/db/lib/slack/blocks.js
@@ -52,6 +52,48 @@ const messageBlocks = {
         }]
     },
     /**
+     * 
+     * Notification a volunteer receives when they check off all three task boxes. 
+     * @returns {array} = Slack block array of block objects
+     */
+    tasksCompleteVolunteer: () => {
+        return [{
+            type: "section",
+            text: {
+                type: "mrkdwn",
+                text: "Welcome to Code for Chicago as an official member! After we assess your background and preferences to determine the best fit for a project, you will receive a notification soon with more details to confirm the assignment."
+            }
+        }, {
+            type: "section",
+            text: {
+                type: "mrkdwn",
+                text: "In the meantime, checkout *#announcements* to stay tuned to important updates and events from Code for Chicago."
+            }
+        }, {
+            type: "section",
+            text: {
+                type: "mrkdwn",
+                text: "Please reach out to your volunteer coordinator or send a message in *#volunteer-onboarding* with any questions or concerns."
+            }
+        }]
+    },
+    /**
+     * 
+     * Notification an admin recieves when a volunteer checks off all three task boxes. 
+     * 
+     * @param {string} volunteer - the volunteer who finished the tasks.
+     * @returns {array} - Slack block array of block options
+     */
+    tasksCompleteAdmin: (volunteer) => {
+        return [{
+            type: "section",
+            text: {
+                type: "mrkdwn",
+                text: `Onboarding complete: *${volunteer}* has completed the Trello tickets for initial onboarding and has officially joined as a Code for Chicago member. Please view the Recommendation tab in Voma to fit this volunteer to the right project.`
+            }
+        }]
+    },
+    /**
      * Welcome to project message block.
      * 
      * @param {object} project - Object with project information for the welcome message.

--- a/db/lib/slack/slack.js
+++ b/db/lib/slack/slack.js
@@ -165,6 +165,9 @@ const token = process.env?.SLACK_BOT_TOKEN || '';
  * @param {array}  blockParams - (optional) Block params if needed. 
  */
  const slackBlockMessageUser = async (slackUserId, blockName, blockParams=false) => {
+    console.log("sending message");
+    console.log(slackUserId);
+    console.log(blockName);
     if (!blockName || !slackUserId || (typeof blockParams == 'undefined')) return false;
 
     if (! messageBlocks[blockName]) { // Check that block is configured.
@@ -174,7 +177,7 @@ const token = process.env?.SLACK_BOT_TOKEN || '';
 
     let blockFn = messageBlocks[blockName];
     let blocks = blockFn(blockParams);
-
+    console.log(blocks);
     try {
         let params = {
             channel: slackUserId,
@@ -189,7 +192,10 @@ const token = process.env?.SLACK_BOT_TOKEN || '';
         };
         const result = await axios
                         .post(`${apiEndpoint}/chat.postMessage`, params, options)
-                        .then(res =>  res.data);
+                        .then((res) => {
+                            console.log('success?');
+                            return res.data;
+                        });
 
         return result;
 

--- a/db/lib/slack/slack.js
+++ b/db/lib/slack/slack.js
@@ -165,9 +165,6 @@ const token = process.env?.SLACK_BOT_TOKEN || '';
  * @param {array}  blockParams - (optional) Block params if needed. 
  */
  const slackBlockMessageUser = async (slackUserId, blockName, blockParams=false) => {
-    console.log("sending message");
-    console.log(slackUserId);
-    console.log(blockName);
     if (!blockName || !slackUserId || (typeof blockParams == 'undefined')) return false;
 
     if (! messageBlocks[blockName]) { // Check that block is configured.
@@ -193,8 +190,6 @@ const token = process.env?.SLACK_BOT_TOKEN || '';
         const result = await axios
                         .post(`${apiEndpoint}/chat.postMessage`, params, options)
                         .then((res) => {
-                            console.log('success?');
-                            console.log(res);
                             return res.data;
                         });
 

--- a/db/lib/slack/slack.js
+++ b/db/lib/slack/slack.js
@@ -194,6 +194,7 @@ const token = process.env?.SLACK_BOT_TOKEN || '';
                         .post(`${apiEndpoint}/chat.postMessage`, params, options)
                         .then((res) => {
                             console.log('success?');
+                            console.log(res);
                             return res.data;
                         });
 


### PR DESCRIPTION
When a volunteer finishes onboarding, they will now receive a slackbot notification containing three checkboxes for tasks they need to complete. As they check off each task, it updates the database. When all three tasks are completed, it sends a notification to the volunteer letting them know next steps, and a separate notification to all admins letting them know that the volunteer has completed the tasks. 